### PR TITLE
Bug fixes and unit tests

### DIFF
--- a/openweave/tlv/schema/obj.py
+++ b/openweave/tlv/schema/obj.py
@@ -245,7 +245,7 @@ common => VENDOR [ id 0 ]
                     if refNode.targetTypeDef.type in visitedRefNodes:
                         _addSchemaError(errs, msg='circular type reference: %s' % refNode.targetName,
                                         detail='the given type reference ultimately refers to itself',
-                                        sourceRef=refNode.nameSourceRef)
+                                        sourceRef=refNode.sourceRef)
                         break
                     refNode = refNode.targetTypeDef.type
                 else:

--- a/openweave/tlv/schema/tests/__init__.py
+++ b/openweave/tlv/schema/tests/__init__.py
@@ -33,6 +33,7 @@ from .test_LIST import Test_LIST
 from .test_MESSAGE import Test_MESSAGE
 from .test_PROFILE import Test_PROFILE
 from .test_qualifiers import Test_Qualifiers
+from .test_refs import Test_Refs
 from .test_STATUS_CODE import Test_STATUS_CODE
 from .test_STRUCTURE import Test_STRUCTURE
 from .test_syntax import Test_Syntax

--- a/openweave/tlv/schema/tests/test_INTEGER.py
+++ b/openweave/tlv/schema/tests/test_INTEGER.py
@@ -24,8 +24,6 @@
 
 import unittest
 
-from openweave.tlv.schema import WeaveTLVSchema
-from openweave.tlv.schema.node import TypeDef
 from .testutils import TLVSchemaTestCase
 
 class Test_INTEGER(TLVSchemaTestCase):

--- a/openweave/tlv/schema/tests/test_MESSAGE.py
+++ b/openweave/tlv/schema/tests/test_MESSAGE.py
@@ -24,7 +24,7 @@
 
 import unittest
 
-from openweave.tlv.schema.node import ArrayType, SignedIntegerType
+from ..node import ArrayType, SignedIntegerType
 from .testutils import TLVSchemaTestCase
 
 class Test_MESSAGE(TLVSchemaTestCase):

--- a/openweave/tlv/schema/tests/test_STRUCTURE.py
+++ b/openweave/tlv/schema/tests/test_STRUCTURE.py
@@ -216,6 +216,36 @@ class Test_STRUCTURE(TLVSchemaTestCase):
         self.assertError(errs, 'duplicate tag in FIELD GROUP type: 0 (context-specific)')
         self.assertError(errs, 'duplicate tag in STRUCTURE type: 0 (context-specific)')
 
+    def test_STRUCTURE_MissingTags(self):
+        schemaText = '''
+                     s => STRUCTURE
+                     {
+                         f1 [0] : INTEGER,
+                         f2     : STRING, // this field is missing a tag
+                     }
+                     '''
+        (tlvSchema, errs) = self.loadValidate(schemaText)
+        self.assertErrorCount(errs, 1)
+        self.assertError(errs, 'missing tag on STRUCTURE type field: f2')
+
+    def test_STRUCTURE_MissingTags_ChoiceAlternate(self):
+        schemaText = '''
+                     s => STRUCTURE
+                     {
+                         f1 : CHOICE OF
+                         {
+                             alt1 : STRUCTURE // this alternate does not declare a tag
+                             {
+                                 f1 [0] : NULL
+                             },
+                             alt2 [0] : INTEGER
+                         }
+                     }
+                     '''
+        (tlvSchema, errs) = self.loadValidate(schemaText)
+        self.assertErrorCount(errs, 1)
+        self.assertError(errs, 'missing tag on STRUCTURE type field: f1')
+
     def test_STRUCTURE_possibleTags(self):
         schemaText = '''
                      s => STRUCTURE
@@ -251,7 +281,7 @@ class Test_STRUCTURE(TLVSchemaTestCase):
                      }
                      '''
         (tlvSchema, errs) = self.loadValidate(schemaText)
-        self.assertErrorCount(errs, 0)
+        self.assertNoErrors(errs)
         s = tlvSchema.getTypeDef('s').targetType
         # field f1
         possibleTags = s.getField('f1').possibleTags

--- a/openweave/tlv/schema/tests/test_refs.py
+++ b/openweave/tlv/schema/tests/test_refs.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+
+#
+#   Copyright (c) 2020 Google LLC.
+#   All rights reserved.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+#
+#   @file
+#         Unit tests for reference types.
+#
+
+import unittest
+
+from .testutils import TLVSchemaTestCase
+from ..node import ReferencedType, TypeDef, SignedIntegerType
+
+class Test_Refs(TLVSchemaTestCase):
+    
+    def test_Refs(self):
+        schemaText = '''
+                     s => STRUCTURE
+                     {
+                         f1 [0] : i,
+                     }
+                     c => CHOICE OF
+                     {
+                         alt1 : i,
+                     }
+                     a1 => ARRAY OF i
+                     a2 => ARRAY
+                     {
+                         i
+                     }
+                     l1 => LIST OF i
+                     l2 => LIST
+                     {
+                         i
+                     }
+                     x => i
+                     i => INTEGER
+                     '''
+        (tlvSchema, errs) = self.loadValidate(schemaText)
+        self.assertNoErrors(errs)
+        
+        def assertRefType(refType):
+            self.assertIsInstance(refType, ReferencedType)
+            self.assertIsInstance(refType.targetTypeDef, TypeDef)
+            self.assertEqual(refType.targetTypeDef.name, "i")
+            self.assertIsInstance(refType.targetType, SignedIntegerType)
+        
+        s = tlvSchema.getTypeDef('s').targetType
+        refType = s.getField('f1').type
+        assertRefType(refType)
+
+        c = tlvSchema.getTypeDef('c').targetType
+        refType = c.getAlternate('alt1').type
+        assertRefType(refType)
+
+        a1 = tlvSchema.getTypeDef('a1').targetType
+        refType = a1.elemType
+        assertRefType(refType)
+
+        a2 = tlvSchema.getTypeDef('a2').targetType
+        refType = a2.elemTypePattern[0].type
+        assertRefType(refType)
+
+        l1 = tlvSchema.getTypeDef('l1').targetType
+        refType = l1.elemType
+        assertRefType(refType)
+
+        l2 = tlvSchema.getTypeDef('l2').targetType
+        refType = l2.elemTypePattern[0].type
+        assertRefType(refType)
+
+        refType = tlvSchema.getTypeDef('x').type
+        assertRefType(refType)
+
+    def test_Refs_UndefinedTypeName(self):
+        schemaText = '''
+                     s => STRUCTURE
+                     {
+                         f1 [0] : u,
+                     }
+                     '''
+        (tlvSchema, errs) = self.loadValidate(schemaText)
+        self.assertErrorCount(errs, 1)
+        self.assertError(errs, 'invalid type reference: u')
+
+        schemaText = '''
+                     c => CHOICE OF
+                     {
+                         alt1 : u,
+                     }
+                     '''
+        (tlvSchema, errs) = self.loadValidate(schemaText)
+        self.assertErrorCount(errs, 1)
+        self.assertError(errs, 'invalid type reference: u')
+
+        schemaText = '''
+                     a1 => ARRAY OF u
+                     '''
+        (tlvSchema, errs) = self.loadValidate(schemaText)
+        self.assertErrorCount(errs, 1)
+        self.assertError(errs, 'invalid type reference: u')
+
+        schemaText = '''
+                     a2 => ARRAY
+                     {
+                         u
+                     }
+                     '''
+        (tlvSchema, errs) = self.loadValidate(schemaText)
+        self.assertErrorCount(errs, 1)
+        self.assertError(errs, 'invalid type reference: u')
+
+        schemaText = '''
+                     l1 => LIST OF u
+                     '''
+        (tlvSchema, errs) = self.loadValidate(schemaText)
+        self.assertErrorCount(errs, 1)
+        self.assertError(errs, 'invalid type reference: u')
+
+        schemaText = '''
+                     l2 => LIST
+                     {
+                         u
+                     }
+                     '''
+        (tlvSchema, errs) = self.loadValidate(schemaText)
+        self.assertErrorCount(errs, 1)
+        self.assertError(errs, 'invalid type reference: u')
+
+        schemaText = '''
+                     s => STRUCTURE
+                     {
+                         f1 : CHOICE OF
+                         {
+                             alt1 : u
+                         }
+                     }
+                     '''
+        (tlvSchema, errs) = self.loadValidate(schemaText)
+        self.assertErrorCount(errs, 2)
+        self.assertError(errs, 'invalid type reference: u')
+        self.assertError(errs, 'missing tag on STRUCTURE type field: f1')
+
+        schemaText = '''
+                     s => STRUCTURE
+                     {
+                         f1 : CHOICE OF
+                         {
+                             alt1 : x
+                         }
+                     }
+                     x [0] => u
+                     '''
+        (tlvSchema, errs) = self.loadValidate(schemaText)
+        self.assertErrorCount(errs, 1)
+        self.assertError(errs, 'invalid type reference: u')
+
+    def test_Refs_CircularRefs(self):
+        schemaText = '''
+                     x => x
+                     '''
+        (tlvSchema, errs) = self.loadValidate(schemaText)
+        self.assertErrorCount(errs, 1)
+        self.assertError(errs, 'circular type reference: x')
+
+        schemaText = '''
+                     a => b
+                     b => c
+                     c => d
+                     d => e
+                     e => f
+                     f => a
+                     '''
+        (tlvSchema, errs) = self.loadValidate(schemaText)
+        self.assertErrorCount(errs, 6)
+        self.assertError(errs, 'circular type reference: a')
+        self.assertError(errs, 'circular type reference: b')
+        self.assertError(errs, 'circular type reference: c')
+        self.assertError(errs, 'circular type reference: d')
+        self.assertError(errs, 'circular type reference: e')
+        self.assertError(errs, 'circular type reference: f')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/openweave/tlv/schema/tests/test_tags.py
+++ b/openweave/tlv/schema/tests/test_tags.py
@@ -24,8 +24,7 @@
 
 import unittest
 
-from openweave.tlv.schema import WeaveTLVSchema
-from openweave.tlv.schema.node import TypeDef
+from ..node import TypeDef
 from .testutils import TLVSchemaTestCase
 
 class Test_Tags(TLVSchemaTestCase):

--- a/openweave/tlv/schema/tests/testutils.py
+++ b/openweave/tlv/schema/tests/testutils.py
@@ -28,8 +28,8 @@ import sys
 import os
 import io
 
-from openweave.tlv.schema import WeaveTLVSchema
-from openweave.tlv.schema.error import WeaveTLVSchemaError
+from .. import WeaveTLVSchema
+from ..error import WeaveTLVSchemaError
 
 class TLVSchemaTestCase(unittest.TestCase):
 


### PR DESCRIPTION
- Fixed crash when detecting circular type references.

- Fixed crash when schema includes a reference to an undefined type.

- Fixed crash when choice alternate inside a structure field does not define a tag.

- Added unit tests for testing type references and APIs on the ReferenceType class.

- Added unit tests for missing tags on structure fields.

- Cleaned up inter-module import statements.